### PR TITLE
Web: Prevent incompatible Node versions from attempting to build bindings

### DIFF
--- a/binding/web/.npmrc
+++ b/binding/web/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/binding/web/package.json
+++ b/binding/web/package.json
@@ -17,5 +17,8 @@
   "devDependencies": {
     "edit-json-file": "^1.5.0",
     "ncp": "^2.0.0"
+  },
+  "engines": {
+    "node": ">=12"
   }
 }


### PR DESCRIPTION
Node 12 is needed to be able to compile ESM etc. Prevent users from proceeding with a hard check.